### PR TITLE
Improve reliability by draining UART buffer at every read

### DIFF
--- a/pzem.py
+++ b/pzem.py
@@ -266,7 +266,7 @@ class PZEM:
 
         # Read the response, maximun 25 bytes
         # (25 bytes = (2 * 10 + 1 + 1 + 1 ) + 2 CRC )
-        self.rcvFrame = self.uart.read(buf)
+        self.rcvFrame = self.uart.read() or b''
 
         # Update reading time
         self.readingTime = time.ticks_ms() - tStart
@@ -274,9 +274,9 @@ class PZEM:
         frame = list(self.rcvFrame)
 
         if (
-            self.checkCRC16(frame)
+            len(frame) == buf
+            and self.checkCRC16(frame)
             and self.checkResponse(frame)
-            and len(frame) == (buf - 2)
             and self.updateValue(frame=frame, reg=regAddr)
         ):
             return True


### PR DESCRIPTION
Always read all data from UART buffer. Make sure list(buffer) always gets a byte string instead of None in case of read timeout.

We had a reliability problem where a PZEM device failed to read energy once and then did not recover unless power-cycled. Our hypothesis is the UART is reading an occasional stray octet due to interference, and since the driver is reading only the expected response size, any extra octet may offset and hinder all future transactions.

Since we implemented this change in our code, it has been able to recover from errors.

Disclaimer: we use a modified version of this driver to better fit our framework https://github.com/elvis-epx/IoT/blob/main/mpy/lib/third/pzem.py 